### PR TITLE
LI-28 Fixed synchronization Presentation with Model

### DIFF
--- a/Source/Animation.swift
+++ b/Source/Animation.swift
@@ -51,7 +51,6 @@ public final class Animation {
         )
         animation.beginTime = delay as? CFTimeInterval ?? 0
         animation.fillMode = .forwards
-        animation.isRemovedOnCompletion = false
         animation.timingFunction = easingType.isComplex ?
             CAMediaTimingFunction(name: .linear) :
             easingType.timingFunction
@@ -64,7 +63,6 @@ public final class Animation {
         animation.path = path
         animation.beginTime = delay as? CFTimeInterval ?? 0
         animation.fillMode = .forwards
-        animation.isRemovedOnCompletion = false
         animation.timingFunction = easingType.isComplex ?
             CAMediaTimingFunction(name: .linear) :
             easingType.timingFunction

--- a/Source/AnimationQueue.swift
+++ b/Source/AnimationQueue.swift
@@ -7,7 +7,7 @@
 //
 
 final class AnimationQueue: NSObject {
-    private lazy var identifier = String(UInt(bitPattern: ObjectIdentifier(self)))
+    private lazy var identifier = String(describing: ObjectIdentifier(self))
 
     private let layer: CALayer
     private var closures: [(AnimationMaker) -> Void] = []

--- a/Source/AnimationQueue.swift
+++ b/Source/AnimationQueue.swift
@@ -7,6 +7,8 @@
 //
 
 final class AnimationQueue: NSObject {
+    private lazy var identifier = String(UInt(bitPattern: ObjectIdentifier(self)))
+
     private let layer: CALayer
     private var closures: [(AnimationMaker) -> Void] = []
 
@@ -20,7 +22,7 @@ final class AnimationQueue: NSObject {
         }
         let animationGroup = AnimationMaker.makeAnimation(item: layer, closure: closure)
         animationGroup.delegate = self
-        layer.add(animationGroup, forKey: nil)
+        layer.add(animationGroup, forKey: identifier)
     }
 
     func enqueue(_ closure: ((AnimationMaker) -> Void)?) {
@@ -48,6 +50,7 @@ extension AnimationQueue: CAAnimationDelegate {
             layer.transform = presentationLayer.transform
             layer.opacity = presentationLayer.opacity
             layer.position = presentationLayer.position
+            layer.removeAnimation(forKey: identifier)
         }
         run()
     }


### PR DESCRIPTION
## Status
<!--- Select option. ---> 
ready

## Issue
<!--- Specify the issue and select option. ---> 
fixes #28 

## Notes
<!--- Optional, remove if not needed. ---> 
It happens due to all animations have `isRemovedOnCompletion` set to `true` and animations had never removed, so presentation tree can't update correctly. But we still need this property to be `true` to synchronize presentation with model.
